### PR TITLE
Move from beta congress.gov URLs to new ones (which also HTTPS)

### DIFF
--- a/tasks/bills/bills.rb
+++ b/tasks/bills/bills.rb
@@ -366,7 +366,7 @@ class Bills
 
   # todo: when they expand to earlier (or later) congresses, 'th' is not a universal ordinal
   def self.congress_gov_url(congress, type, number)
-    "http://beta.congress.gov/bill/#{congress}th/#{congress_gov_type type}/#{number}"
+    "https://www.congress.gov/bill/#{congress}th/#{congress_gov_type type}/#{number}"
   end
 
   def self.congress_gov_type(bill_type)

--- a/test/functional/query_test.rb
+++ b/test/functional/query_test.rb
@@ -33,7 +33,7 @@ class QueryTest < Test::Unit::TestCase
       official_title: "A title",
       bill_id: "hr1234-113",
       urls: {
-        congress: "http://beta.congress.gov/bill/113th-congress/house-bill/1234"
+        congress: "https://www.congress.gov/bill/113th-congress/house-bill/1234"
       },
       introduced_on: "2013-04-05",
       summary: "A great bill"
@@ -56,7 +56,7 @@ class QueryTest < Test::Unit::TestCase
       official_title: "A title",
       bill_id: "hr1234-113",
       urls: {
-        congress: "http://beta.congress.gov/bill/113th-congress/house-bill/1234"
+        congress: "https://www.congress.gov/bill/113th-congress/house-bill/1234"
       },
       introduced_on: "2013-04-05",
       summary: "A great bill"


### PR DESCRIPTION
`http://beta.congress.gov` long ago moved to `https://www.congress.gov`. This updates the utility function and tests to use this URL.
