### PR TITLE
Add test cases for boolean query parsing

### DIFF
--- a/test/functional/query_test.rb
+++ b/test/functional/query_test.rb
@@ -75,4 +75,42 @@ class QueryTest < Test::Unit::TestCase
     assert_match /hr1234/, last_response.body
   end
 
+  def test_boolean_parsing
+    bill = Bill.create!(
+      bill_id: "hr1234-113",
+      introduced_on: "2013-04-05",
+      history: {
+        enacted: true
+      }
+    )
+
+    # TODO: move "True" case to the success array
+    success = [true, "true"]
+    failure = [false, "false", "False", "True"]
+
+    success.each do |value|
+      get "/bills", {
+        bill_id: "hr1234-113",
+        "history.enacted" => value
+      }
+
+      assert_response 200
+      assert_json
+
+      assert_match /hr1234/, last_response.body, "Using history.enacted = #{value}"
+    end
+
+    failure.each do |value|
+      get "/bills", {
+        bill_id: "hr1234-113",
+        "history.enacted" => value
+      }
+
+      assert_response 200
+      assert_json
+
+      assert_no_match /hr1234/, last_response.body, "Using history.enacted = #{value}"
+    end
+  end
+
 end

--- a/test/functional/query_test.rb
+++ b/test/functional/query_test.rb
@@ -88,6 +88,10 @@ class QueryTest < Test::Unit::TestCase
     success = [true, "true"]
     failure = [false, "false", "False", "True"]
 
+    # note: using nil or '' will cause the query to be disregarded,
+    # which will make the bill return, but not because of the behavior
+    # this test is evaluating (so is not tested here).
+
     success.each do |value|
       get "/bills", {
         bill_id: "hr1234-113",


### PR DESCRIPTION
This adds some base test cases that make sure boolean query parsing works as expected.

This PR as filed tests a few values of `true` and `false`, and has a `TODO` to make `"True"` a passing value. I'm working on another commit that will test some unusual values.
